### PR TITLE
Fix mspelling version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 0.2.0
+current_version = 0.2.1
 
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release.
 
-[Unreleased]: https://github.com/mario-bermonti/mspelling/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/mario-bermonti/mspelling/compare/releases/tag/v0.2.0
+[Unreleased]: https://github.com/mario-bermonti/mspelling/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/mario-bermonti/mspelling/compare/releases/tag/v0.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.poetry]
 name = "mspelling"
-version = "0.2.0"
+version = "0.2.1"
 description = "Measure of Spanish spelling skills"
 authors = ["Mario E. Bermonti Pérez <mbermonti1132@gmail.com>"]
 

--- a/src/mspelling/__init__.py
+++ b/src/mspelling/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Mario E. Bermonti Pérez"""
 __email__ = "mbermonti1132@gmail.com"
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
-------

## Description

<!-- Add a detailed description of the changes if needed. -->

Because the process of bumping mspelling's version was done manually, it's metadata lack behind its actual version. The tags are correct, not the metadata.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->