### PR TITLE
Add-rest-period

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Measure of Spanish spelling skills
 ![demo](./mspelling_gif.gif)
 
 Words are presented by the computer one at a time and the participant types the word
-using the keyboard.
+using the keyboard. Participants have a rest period after every 5 trials.
 
 At the end of the session, mspelling saves the results to a CSV file, which is supported
 by most popular spreadsheet software these days (e.g., Excel).

--- a/src/mspelling/main.py
+++ b/src/mspelling/main.py
@@ -17,6 +17,7 @@ from .ui.beginmessagescreen import BeginMessageScreen
 from .ui.spellingactivity import SpellingActivityScreen
 from .ui.savescreen import SaveScreen
 from .ui.endscreen import EndScreen
+from .ui.restscreen import RestPeriodScreen
 
 from .results import Results
 

--- a/src/mspelling/ui/mspelling.kv
+++ b/src/mspelling/ui/mspelling.kv
@@ -32,5 +32,8 @@
         EndScreen:
             id: end_screen
             name: "end_screen"
+        RestPeriodScreen:
+            id: rest_period_screen
+            name: "rest_period_screen"
 
 MSpellingRoot:

--- a/src/mspelling/ui/restscreen.kv
+++ b/src/mspelling/ui/restscreen.kv
@@ -1,0 +1,15 @@
+#:include src/mspelling/ui/elements.kv
+#:set message_size dp(35)
+
+<RestPeriodScreen>:
+    ThemedLayout:
+        ThemedLabel:
+            text: "¡Toma un descanso!"
+            size_hint: (1, .1)
+            pos_hint: {"center_x": .5, "y": .3}
+            halign: "center"
+        ThemedButton:
+            size_hint: (1, .03)
+            text: "Pressiona para comenzar"
+            on_press:
+                root.manager.current = "spelling_activity_screen"

--- a/src/mspelling/ui/restscreen.py
+++ b/src/mspelling/ui/restscreen.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from kivymd.uix.screen import MDScreen
+from kivy.lang import Builder
+
+
+# TODO Improve this
+# The ui is not build if the kv file is not manually loaded
+path_root = Path(__file__).resolve().parent / "restscreen.kv"
+Builder.load_file(str(path_root))
+
+class RestPeriodScreen(MDScreen):
+    pass


### PR DESCRIPTION
## Description

<!-- Add a detailed description of the changes if needed. -->

Participants are presented with a rest period after every 5 trials. It is self-paced so participants must press a button to continue working on mspelling.

## Related Issue

fix #43

<!-- If your PR refers to a related issue, link it here using `fix #[number-of-issue]`. -->
<!-- If this is not related to an issue, please delete this section (`Related Issue`). -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
