### PR TITLE
Increase ITI

### DIFF
--- a/src/mspelling/main.py
+++ b/src/mspelling/main.py
@@ -1,24 +1,23 @@
 from pathlib import Path
 
 import kivy
-kivy.require('1.11.1')
-from kivymd.app import MDApp
-from kivy.properties import StringProperty
-from kivy.properties import BooleanProperty
-from kivy.properties import ObjectProperty
+
+kivy.require("1.11.1")
 from kivy.lang import Builder
+from kivy.properties import BooleanProperty, ObjectProperty, StringProperty
+from kivymd.app import MDApp
+
+from .results import Results
+from .ui.beginmessagescreen import BeginMessageScreen
+from .ui.endscreen import EndScreen
+from .ui.loginscreen import LoginScreen
+from .ui.savescreen import SaveScreen
+from .ui.spellingactivity import SpellingActivityScreen
+from .ui.startscreen import StartScreen
 
 # needs to be imported or kivy won't find them
 # at least the first screen
 from .ui.welcomescreen import WelcomeScreen
-from .ui.loginscreen import LoginScreen
-from .ui.startscreen import StartScreen
-from .ui.beginmessagescreen import BeginMessageScreen
-from .ui.spellingactivity import SpellingActivityScreen
-from .ui.savescreen import SaveScreen
-from .ui.endscreen import EndScreen
-
-from .results import Results
 
 
 class MSpellingApp(MDApp):
@@ -46,8 +45,7 @@ class MSpellingApp(MDApp):
         self.results.save_results()
 
     def determine_session_name(self):
-        """Determine the kind of session. Options are 'demo', 'practice', 'experimental'.
-        """
+        """Determine the kind of session. Options are 'demo', 'practice', 'experimental'."""
 
         if self.participant_id == "demo":
             self.session_name = "demo"

--- a/src/mspelling/results.py
+++ b/src/mspelling/results.py
@@ -1,9 +1,11 @@
-from pathlib import Path
-from kivy.app import App
-import pandas as pd
 import datetime
+from pathlib import Path
+
+import pandas as pd
+from kivy.app import App
 
 PATH_CWD = Path().cwd()
+
 
 class Results(object):
     """Manages, stores and saves results from the session."""
@@ -24,10 +26,7 @@ class Results(object):
             the stimuli.
         """
 
-        results_trial = self.format_trial_results(
-            response,
-            trial_data
-        )
+        results_trial = self.format_trial_results(response, trial_data)
         self._results.append(results_trial)
 
     def format_trial_results(self, response, trial_data):
@@ -107,7 +106,7 @@ class Results(object):
             Index specifying the order of the trial's data.
         """
 
-        trial_data = trial_data.copy() # don't modify original data
+        trial_data = trial_data.copy()  # don't modify original data
         other_data = trial_data.drop(labels="word")
 
         index_other_data = other_data.index
@@ -139,7 +138,6 @@ class Results(object):
 
         return results_formatted
 
-
     def save_results_file(self, results, testing=False):
         """Save results to file, creating the dir if it doesn't exist.
 
@@ -149,7 +147,7 @@ class Results(object):
             Participant's results for the session
         """
 
-        date = datetime.datetime.now().strftime('%Y-%m-%d-h%H-m%M')
+        date = datetime.datetime.now().strftime("%Y-%m-%d-h%H-m%M")
 
         participant_id = self.get_participant_id(testing)
 
@@ -163,10 +161,9 @@ class Results(object):
         doesn't already exist.
         """
 
-        path_results = PATH_CWD / 'results'
+        path_results = PATH_CWD / "results"
         if not path_results.exists():
             path_results.mkdir()
-
 
     def get_participant_id(self, testing=False):
         """Get participant id.

--- a/src/mspelling/ui/beginmessagescreen.py
+++ b/src/mspelling/ui/beginmessagescreen.py
@@ -1,5 +1,6 @@
-from kivymd.uix.screen import MDScreen
 from kivy.clock import Clock
+from kivymd.uix.screen import MDScreen
+
 
 class BeginMessageScreen(MDScreen):
     def on_enter(self):

--- a/src/mspelling/ui/endscreen.py
+++ b/src/mspelling/ui/endscreen.py
@@ -1,6 +1,7 @@
-from kivymd.uix.screen import MDScreen
-from kivy.core.window import Window
 from kivy.app import App
+from kivy.core.window import Window
+from kivymd.uix.screen import MDScreen
+
 
 class EndScreen(MDScreen):
     def on_enter(self):

--- a/src/mspelling/ui/loginscreen.kv
+++ b/src/mspelling/ui/loginscreen.kv
@@ -14,6 +14,6 @@
         ThemedButton:
             size_hint: (1, .03)
             text: "Seguir"
-            on_press:
+            on_release:
                 root.submit_participant_id(code_input.text)
                 root.manager.current = "start_screen"

--- a/src/mspelling/ui/loginscreen.py
+++ b/src/mspelling/ui/loginscreen.py
@@ -1,5 +1,6 @@
-from kivymd.uix.screen import MDScreen
 from kivy.app import App
+from kivymd.uix.screen import MDScreen
+
 
 class LoginScreen(MDScreen):
     def on_enter(self):

--- a/src/mspelling/ui/savescreen.py
+++ b/src/mspelling/ui/savescreen.py
@@ -1,6 +1,7 @@
-from kivymd.uix.screen import MDScreen
 from kivy.app import App
 from kivy.clock import Clock
+from kivymd.uix.screen import MDScreen
+
 
 class SaveScreen(MDScreen):
     def on_enter(self):

--- a/src/mspelling/ui/spellingactivity.kv
+++ b/src/mspelling/ui/spellingactivity.kv
@@ -12,6 +12,7 @@
             disabled: True
             size_hint: (1, .03)
         ThemedButton:
+            id: submit_button
             text: "Seguir"
             on_release:
                 root.submit(response_input.text)

--- a/src/mspelling/ui/spellingactivity.kv
+++ b/src/mspelling/ui/spellingactivity.kv
@@ -13,7 +13,7 @@
             size_hint: (1, .03)
         ThemedButton:
             text: "Seguir"
-            on_press:
+            on_release:
                 root.submit(response_input.text)
             size_hint: (1, .03)
             pos_hint: {"center_x": .5, "center_y": .3}

--- a/src/mspelling/ui/spellingactivity.py
+++ b/src/mspelling/ui/spellingactivity.py
@@ -56,7 +56,7 @@ class SpellingActivityScreen(MDScreen):
             response=response,
             trial_data=self.trial,
             )
-
+        self.reset_everything()
         self.trial_number += 1        
         if self.active_session and not self.rest_period_active:
             Clock.schedule_once(self.present_trial, 1)

--- a/src/mspelling/ui/spellingactivity.py
+++ b/src/mspelling/ui/spellingactivity.py
@@ -1,12 +1,11 @@
-from kivymd.uix.screen import MDScreen
-from kivy.app import App
-from kivy.properties import ObjectProperty
-from kivy.properties import BooleanProperty
-from kivy.core.audio import SoundLoader
-from kivy.clock import Clock
-
 from functools import partial
+
 import pandas as pd
+from kivy.app import App
+from kivy.clock import Clock
+from kivy.core.audio import SoundLoader
+from kivy.properties import BooleanProperty, ObjectProperty
+from kivymd.uix.screen import MDScreen
 
 from ..worksheet import Worksheet
 
@@ -39,7 +38,7 @@ class SpellingActivityScreen(MDScreen):
         self.results.update_results(
             response=response,
             trial_data=self.trial,
-            )
+        )
         self.reset_everything()
         if self.active_session:
             Clock.schedule_once(self.present_trial, 1)
@@ -109,11 +108,7 @@ class SpellingActivityScreen(MDScreen):
         if self.active_session:
             self.present_audio()
             Clock.schedule_once(
-                partial(
-                    self.toggle_disabling_response,
-                    disable_response=False
-                ),
-                1
+                partial(self.toggle_disabling_response, disable_response=False), 1
             )
 
     def present_audio(self):

--- a/src/mspelling/ui/spellingactivity.py
+++ b/src/mspelling/ui/spellingactivity.py
@@ -128,6 +128,7 @@ class SpellingActivityScreen(MDScreen):
         """Enable or disable user's response."""
 
         self.ids.response_input.disabled = disable_response
+        self.ids.submit_button.disabled = disable_response
         self.ids.response_input.focus = True
 
     def end_spelling_activity(self):

--- a/src/mspelling/ui/spellingactivity.py
+++ b/src/mspelling/ui/spellingactivity.py
@@ -22,8 +22,8 @@ class SpellingActivityScreen(MDScreen):
         self.BASE_PATH = self.app.get_base_path()
         self.worksheet = self.get_stimuli()
         self.trial = None
-        self.present_trial()
         self.results = self.app.results
+        self.present_trial()
 
     def submit(self, response):
         """Pass the participant's response to the appropriate function

--- a/src/mspelling/ui/spellingactivity.py
+++ b/src/mspelling/ui/spellingactivity.py
@@ -17,6 +17,7 @@ class SpellingActivityScreen(MDScreen):
     active_session = BooleanProperty(True)
 
     def on_enter(self):
+        self.reset_everything()
         self.app = App.get_running_app()
         self.app.determine_session_name()
         self.BASE_PATH = self.app.get_base_path()
@@ -39,6 +40,7 @@ class SpellingActivityScreen(MDScreen):
             response=response,
             trial_data=self.trial,
             )
+        self.reset_everything()
         if self.active_session:
             Clock.schedule_once(self.present_trial, 1)
 
@@ -103,8 +105,6 @@ class SpellingActivityScreen(MDScreen):
         the response would be contaminated by that cue.
         """
 
-        self.clear_screen()
-        self.toggle_disabling_response(disable_response=True)
         self.set_trial()
         if self.active_session:
             self.present_audio()

--- a/src/mspelling/ui/spellingactivity.py
+++ b/src/mspelling/ui/spellingactivity.py
@@ -40,7 +40,7 @@ class SpellingActivityScreen(MDScreen):
             trial_data=self.trial,
             )
         if self.active_session:
-            self.present_trial()
+            Clock.schedule_once(self.present_trial, 1)
 
     def get_stimuli(self):
         """Get the stimuli that will be used by the spelling activity.
@@ -95,7 +95,7 @@ class SpellingActivityScreen(MDScreen):
         except IndexError:
             self.end_spelling_activity()
 
-    def present_trial(self):
+    def present_trial(self, *args):
         """Setup and present the trial.
 
         The user's response is delayed to avoid him/her providing

--- a/src/mspelling/ui/startscreen.kv
+++ b/src/mspelling/ui/startscreen.kv
@@ -7,5 +7,5 @@
         pos_hint: {"center_x": 0.5, "center_y":0.5}
         font_size: message_size
         size_hint: (.5, 0.15)
-        on_press:
+        on_release:
             root.manager.current = "begin_message_screen"

--- a/src/mspelling/ui/startscreen.py
+++ b/src/mspelling/ui/startscreen.py
@@ -1,4 +1,5 @@
 from kivymd.uix.screen import MDScreen
 
+
 class StartScreen(MDScreen):
     pass

--- a/src/mspelling/ui/welcomescreen.kv
+++ b/src/mspelling/ui/welcomescreen.kv
@@ -8,5 +8,5 @@
             text: "Seguir"
             size_hint: (1, .05)
             pos_hint: {"center_x": .5, "center_y": .3}
-            on_press:
+            on_release:
                 root.manager.current = "login_screen"

--- a/src/mspelling/ui/welcomescreen.py
+++ b/src/mspelling/ui/welcomescreen.py
@@ -1,4 +1,5 @@
 from kivymd.uix.screen import MDScreen
 
+
 class WelcomeScreen(MDScreen):
     pass

--- a/src/mspelling/worksheet.py
+++ b/src/mspelling/worksheet.py
@@ -1,6 +1,7 @@
 import os
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 
 
 class Worksheet(object):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,5 +1,7 @@
 import pandas as pd
+
 from mspelling.results import Results
+
 
 class TestResults(object):
     """Test results object."""
@@ -16,9 +18,7 @@ class TestResults(object):
 
         results = Results()
         trial_data_returned = results.add_additional_data(
-            response=data["response"],
-            trial_data=trial_data_incomplete,
-            testing=True
+            response=data["response"], trial_data=trial_data_incomplete, testing=True
         )
 
         trial_data_complete = pd.Series(data)

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -1,10 +1,11 @@
 import pandas as pd
+
 from mspelling.worksheet import Worksheet
+
 
 class TestWorksheet(object):
     def test_randomize_stimuli(self):
-        data = {"word": ["perro", "gato", "cerdo"],
-                "meta_data": [4, 4, 5]}
+        data = {"word": ["perro", "gato", "cerdo"], "meta_data": [4, 4, 5]}
         stim = pd.DataFrame(data)
 
         worksheet = Worksheet(stim, randomize=True)


### PR DESCRIPTION
## Description

<!-- Add a detailed description of the changes if needed. -->
Increase ITI, use on_release with buttons to allow more time and avoid accidentally moving to the next step, disable the submit button when disabling the response textbox, use an integrated function for  preparating the screen for a new trial.

## Related Issue

<!-- If your PR refers to a related issue, link it here using `fix #[number-of-issue]`. -->
<!-- If this is not related to an issue, please delete this section (`Related Issue`). -->
fix #61

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
