### PR TITLE
[bug] Fix going back to home page

### DIFF
--- a/mspelling/lib/login/login_controller.dart
+++ b/mspelling/lib/login/login_controller.dart
@@ -4,7 +4,7 @@ import 'package:get/get.dart';
 /// Manager that holds the participant ID
 class LoginController extends GetxController {
   final TextEditingController textController = TextEditingController();
-  late final String participantID;
+  late String participantID;
 
   @override
   void onClose() {


### PR DESCRIPTION
## Description

<!-- Add a detailed description of the changes if needed. -->

Going back to the home page caused an error because the participant ID could not be set more than once (final).

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
